### PR TITLE
fix: loading themes with multiple inheritance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "freedesktop-icon-lookup"
 description = "Freedesktop icons lookup"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/l4l/freedesktop-icon-lookup"

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -86,16 +86,18 @@ impl Cache {
                 };
 
                 if let Some(inherits) = t.inherits() {
-                    self.load_inner(inherits, depth + 1)?;
+                    for inherit in inherits {
+                        self.load_inner(inherit, depth + 1)?;
+                    }
                 }
 
-                if t.inherits().map_or(true, |i| self.themes.contains_key(i)) {
+                if t.inherits().map_or(true, |i| i.iter().all(|x| self.themes.contains_key(x))) {
                     self.themes.entry(theme.clone()).or_default().push(t);
                 } else {
                     #[cfg(feature = "log")]
                     log::warn!(
-                        "skipping {theme} as inherited {} was not loaded",
-                        t.inherits().unwrap()
+                        "skipping {theme:#?} as inherited {} was not loaded",
+                        t.inherits().unwrap().join(",")
                     );
                 }
             }
@@ -182,7 +184,7 @@ impl Cache {
             }
         }
 
-        for theme in themes.iter().filter_map(|t| t.inherits()) {
+        for theme in themes.iter().filter_map(|t| t.inherits()).flatten() {
             if let Some(search) = self.lookup_themed(theme, icon_name, f, depth + 1) {
                 return Some(search);
             }

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -85,19 +85,19 @@ impl Cache {
                     }
                 };
 
-                if let Some(inherits) = t.inherits() {
-                    for inherit in inherits {
+                if !t.inherits().is_empty() {
+                    for inherit in t.inherits() {
                         self.load_inner(inherit, depth + 1)?;
                     }
                 }
 
-                if t.inherits().map_or(true, |i| i.iter().all(|x| self.themes.contains_key(x))) {
+                if t.inherits().iter().all(|x| self.themes.contains_key(x)) {
                     self.themes.entry(theme.clone()).or_default().push(t);
                 } else {
                     #[cfg(feature = "log")]
                     log::warn!(
                         "skipping {theme} as inherited {} was not loaded",
-                        t.inherits().unwrap().join(",")
+                        t.inherits().join(",")
                     );
                 }
             }
@@ -184,7 +184,7 @@ impl Cache {
             }
         }
 
-        for theme in themes.iter().filter_map(|t| t.inherits()).flatten() {
+        for theme in themes.iter().flat_map(|t| t.inherits()) {
             if let Some(search) = self.lookup_themed(theme, icon_name, f, depth + 1) {
                 return Some(search);
             }

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -85,10 +85,8 @@ impl Cache {
                     }
                 };
 
-                if !t.inherits().is_empty() {
-                    for inherit in t.inherits() {
-                        self.load_inner(inherit, depth + 1)?;
-                    }
+                for inherit in t.inherits() {
+                    self.load_inner(inherit, depth + 1)?;
                 }
 
                 if t.inherits().iter().all(|x| self.themes.contains_key(x)) {

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -96,7 +96,7 @@ impl Cache {
                 } else {
                     #[cfg(feature = "log")]
                     log::warn!(
-                        "skipping {theme:#?} as inherited {} was not loaded",
+                        "skipping {theme} as inherited {} was not loaded",
                         t.inherits().unwrap().join(",")
                     );
                 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -10,7 +10,7 @@ use crate::{Directory, Error, Result};
 pub(crate) struct Theme {
     path: PathBuf,
     icon_infos: HashMap<String, Vec<IconInfo>>,
-    inherits: Option<Vec<String>>,
+    inherits: Vec<String>,
 }
 
 impl Theme {
@@ -20,7 +20,8 @@ impl Theme {
 
         let inherits = ini
             .get::<String>("Icon Theme", "Inherits")
-            .map(|x| x.split(',').map(|x| x.to_string()).collect());
+            .map(|x| x.split(',').map(|x| x.trim().to_string()).collect())
+            .unwrap_or_default();
         let directory_names = ini
             .get_vec::<String>("Icon Theme", "Directories")
             .ok_or_else(|| Error::InvalidTheme {
@@ -68,8 +69,8 @@ impl Theme {
         })
     }
 
-    pub(crate) fn inherits(&self) -> Option<&[String]> {
-        self.inherits.as_deref()
+    pub(crate) fn inherits(&self) -> &[String] {
+        &self.inherits
     }
 }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -10,7 +10,7 @@ use crate::{Directory, Error, Result};
 pub(crate) struct Theme {
     path: PathBuf,
     icon_infos: HashMap<String, Vec<IconInfo>>,
-    inherits: Option<String>,
+    inherits: Option<Vec<String>>,
 }
 
 impl Theme {
@@ -18,7 +18,9 @@ impl Theme {
         let path = path.as_ref();
         let ini = read_index(path)?;
 
-        let inherits = ini.get::<String>("Icon Theme", "Inherits");
+        let inherits = ini
+            .get::<String>("Icon Theme", "Inherits")
+            .map(|x| x.split(',').map(|x| x.to_string()).collect());
         let directory_names = ini
             .get_vec::<String>("Icon Theme", "Directories")
             .ok_or_else(|| Error::InvalidTheme {
@@ -66,7 +68,7 @@ impl Theme {
         })
     }
 
-    pub(crate) fn inherits(&self) -> Option<&str> {
+    pub(crate) fn inherits(&self) -> Option<&[String]> {
         self.inherits.as_deref()
     }
 }


### PR DESCRIPTION
Some themes can have more than one inheritance.
Papirus for example: 
![image](https://github.com/l4l/freedesktop-icon-lookup/assets/17771546/c29b9215-1ee2-4b7a-a00c-1fe7ba1ff9bc)

Code snippet for testing:
```rs
use freedesktop_icon_lookup::Cache;

fn main() {
    env_logger::init();
    let mut cache = Cache::new().unwrap();
    cache.load("Papirus").unwrap();
    cache.lookup("telegram", Some("Papirus")).unwrap();
    cache.load("Adwaita").unwrap();
    cache.lookup("telegram", Some("Papirus")).unwrap();
    println!("Successfully loaded!");
}
```

Output:

![image](https://github.com/l4l/freedesktop-icon-lookup/assets/17771546/3e54c0b4-794c-4cab-b109-eb9114b6a0c0)